### PR TITLE
Support samba guest right setting on Sama mode 4 (Access with account)

### DIFF
--- a/trunk/user/httpd/aidisk.c
+++ b/trunk/user/httpd/aidisk.c
@@ -663,6 +663,12 @@ ej_get_all_accounts(int eid, webs_t wp, int argc, char **argv)
 			first = 0;
 			websWrite(wp, "\"%s\"", FTP_ANONYMOUS_USER);
 		}
+	} else if (strcmp(acc_mode, "cifs") == 0) {
+		int st_samba_mode = nvram_get_int("st_samba_mode");
+		if (st_samba_mode == 4) {
+			first = 0;
+			websWrite(wp, "\"%s\"", SMB_GUEST_USER);
+		}
 	}
 
 	get_account_list(&acc_num, &account_list);
@@ -739,6 +745,10 @@ ej_get_permissions_of_account(int eid, webs_t wp, int argc, char **argv)
 		int st_ftp_mode = nvram_get_int("st_ftp_mode");
 		if (st_ftp_mode == 3 || st_ftp_mode == 4)
 			anonym = 1;
+	} else if (strcmp(acc_mode, "cifs") == 0) {
+		int st_samba_mode = nvram_get_int("st_samba_mode");
+		if (st_samba_mode == 4)
+			anonym = 1;
 	}
 
 	if ((acc_num + anonym) <= 0)
@@ -756,7 +766,7 @@ ej_get_permissions_of_account(int eid, webs_t wp, int argc, char **argv)
 		if (i < acc_num)
 			acc_value = account_list[i];
 		else
-			acc_value = FTP_ANONYMOUS_USER;
+			acc_value = /*strcmp(acc_mode, "ftp") ? SMB_GUEST_USER : */FTP_ANONYMOUS_USER;
 
 		websWrite(wp, "if (account == \"%s\") {\n", acc_value);
 

--- a/trunk/user/libdisk/disk_io_tools.c
+++ b/trunk/user/libdisk/disk_io_tools.c
@@ -123,7 +123,7 @@ int test_if_dir(const char *dir) {
 
 int test_if_System_folder(const char *const dirname) {
 	char *MS_System_folder[] = {"SYSTEM VOLUME INFORMATION", "RECYCLER", "RECYCLED", "$RECYCLE.BIN", NULL};
-	char *Linux_System_folder[] = {"lost+found", NULL};
+	char *Linux_System_folder[] = {"lost+found", "opt", "aria", "transmission", NULL};
 	int i;
 	
 	for (i = 0; MS_System_folder[i] != NULL; ++i) {

--- a/trunk/user/libdisk/disk_share.c
+++ b/trunk/user/libdisk/disk_share.c
@@ -349,8 +349,8 @@ int initial_one_var_file_in_mount_path(const char *const account, const char *co
 	}
 
 	// get the samba right and ftp right
-	if (strcmp(account, FTP_ANONYMOUS_USER) == 0) {
-		samba_right = 1;
+	if (strcmp(account, FTP_ANONYMOUS_USER) == 0/* || strcmp(account, SMB_GUEST_USER) == 0*/) {
+		samba_right = 0;
 		ftp_right = 1;
 	}
 	else {

--- a/trunk/user/libdisk/disk_share.h
+++ b/trunk/user/libdisk/disk_share.h
@@ -27,6 +27,7 @@
 #define SHARE_LAYER		(MOUNT_LAYER+1)
 
 #define FTP_ANONYMOUS_USER	"anonymous"
+#define SMB_GUEST_USER		FTP_ANONYMOUS_USER
 
 extern int get_account_list(int *, char ***);
 extern int get_folder_list_in_mount_path(const char *const, int *, char ***);

--- a/trunk/user/rc/services_stor.c
+++ b/trunk/user/rc/services_stor.c
@@ -269,6 +269,8 @@ write_smb_conf(void)
 	fprintf(fp, "dos filemode = yes\n");
 	fprintf(fp, "dos filetimes = yes\n");
 	fprintf(fp, "dos filetime resolution = yes\n");
+	fprintf(fp, "access based share enum = yes\n");
+	fprintf(fp, "veto files = /Thumbs.db/.DS_Store/._.DS_Store/.apdisk/.TemporaryItems/");
 	fprintf(fp, "\n");
 
 	disks_info = read_disk_data();

--- a/trunk/user/rc/services_stor.c
+++ b/trunk/user/rc/services_stor.c
@@ -341,6 +341,8 @@ write_smb_conf(void)
 					int i, right, first;
 					char share[256];
 					
+					int guest_right = get_permission(SMB_GUEST_USER, follow_partition->mount_point, folder_list[n], "cifs");
+
 					memset(share, 0, 256);
 					strcpy(share, folder_list[n]);
 					
@@ -362,10 +364,16 @@ write_smb_conf(void)
 					fprintf(fp, "[%s]\n", share);
 					fprintf(fp, "comment = %s\n", folder_list[n]);
 					fprintf(fp, "path = %s/%s\n", follow_partition->mount_point, folder_list[n]);
-					fprintf(fp, "writeable = no\n");
+					fprintf(fp, /*(guest_right == 2) ? "writeable = yes\n" : */"writeable = no\n");
+					if (guest_right >= 1)
+						fprintf(fp, "guest ok = yes\n");
 					
 					fprintf(fp, "valid users = ");
 					first = 1;
+					if (guest_right >= 1) {
+						first = 0;
+						fprintf(fp, "%s", "nobody");
+					}
 					for (i = 0; i < acc_num; ++i) {
 						right = get_permission(account_list[i], follow_partition->mount_point, folder_list[n], "cifs");
 						if (first == 1)
@@ -395,6 +403,10 @@ write_smb_conf(void)
 					
 					fprintf(fp, "read list = ");
 					first = 1;
+					if (guest_right >= 1) {
+						first = 0;
+						fprintf(fp, "%s", "nobody");
+					}
 					for (i = 0; i < acc_num; ++i) {
 						right = get_permission(account_list[i], follow_partition->mount_point, folder_list[n], "cifs");
 						if (right < 1)
@@ -411,6 +423,10 @@ write_smb_conf(void)
 					
 					fprintf(fp, "write list = ");
 					first = 1;
+					if (guest_right >= 2) {
+						first = 0;
+						fprintf(fp, "%s", "nobody");
+					}
 					for (i = 0; i < acc_num; ++i) {
 						right = get_permission(account_list[i], follow_partition->mount_point, folder_list[n], "cifs");
 						if (right < 2)

--- a/trunk/user/www/n56u_ribbon_fixed/Advanced_AiDisk_samba.asp
+++ b/trunk/user/www/n56u_ribbon_fixed/Advanced_AiDisk_samba.asp
@@ -293,7 +293,7 @@ function onEvent(){
 		$("createAccountBtn").title = (accounts.length < 50)?"<#AddAccountTitle#>":"<#account_overflow#>";
 	}
 	
-	if(this.accounts.length > 0 && this.selectedAccount.length > 0){
+	if(this.accounts.length > 0 && this.selectedAccount.length > 0 && this.selectedAccount != "anonymous"){
 		changeActionButton($("deleteAccountBtn"), 'User', 'Del', 0);
 		changeActionButton($("modifyAccountBtn"), 'User', 'Mod', 0);
 		

--- a/trunk/user/www/n56u_ribbon_fixed/disk_folder_tree.js
+++ b/trunk/user/www/n56u_ribbon_fixed/disk_folder_tree.js
@@ -287,7 +287,7 @@ function showPermissionRadio(barCode, permission){
 	else if(PROTOCOL == "cifs" && permission == 2)
 		code += ' checked';
 
-	if(this.selectedAccount.length <= 0 || this.selectedAccount == "anonymous" || parentPoolStatus != "rw")
+	if(this.selectedAccount.length <= 0 || (this.selectedAccount == "anonymous" && PROTOCOL != 'cifs') || parentPoolStatus != "rw")
 		code += ' disabled';
 
 	code += '>';


### PR DESCRIPTION
1. 主要功能为支持在Samba“账号访问”模式下，新增anonymous账户（实际对应samba guest）的权限设置；
2. 同时调整默认anonymous权限均为0（不可访问），保持默认行为与之前一致；
3. 默认将 "opt", "aria", "transmission" 三个目录排除共享；
4. 使用 veto files 排除特定文件。