### PR TITLE
Aria TLS支持，以及Aria和 Transmission控制台链接优化、默认下载路径

### DIFF
--- a/trunk/user/aria2/aria.sh
+++ b/trunk/user/aria2/aria.sh
@@ -29,7 +29,8 @@ func_start()
 	fi
 
 	DIR_CFG="${DIR_LINK}/config"
-	DIR_DL1="${DIR_LINK}/downloads"
+	DIR_DL1="`cd \"$DIR_LINK\"; dirname \"$(pwd -P)\"`/Downloads"
+	[ ! -d "$DIR_DL1" ] && DIR_DL1="${DIR_LINK}/downloads"
 
 	[ ! -d "$DIR_CFG" ] && mkdir -p "$DIR_CFG"
 
@@ -67,8 +68,8 @@ max-overall-download-limit=0
 disable-ipv6=false
 
 ### File
-file-allocation=trunc
-#file-allocation=falloc
+#file-allocation=trunc
+file-allocation=falloc
 #file-allocation=none
 no-file-allocation-limit=10M
 allow-overwrite=false
@@ -164,9 +165,16 @@ EOF
 		svc_user=" -c nobody"
 	fi
 
+	if [ "`nvram get http_proto`" != "0" ]; then
+		chmod 644 /etc/storage/https/server.crt /etc/storage/https/server.key
+		SSL_OPT="--rpc-secure=true --rpc-certificate=/etc/storage/https/server.crt --rpc-private-key=/etc/storage/https/server.key"
+	else
+		SSL_OPT=
+	fi
+
 	start-stop-daemon -S -N $SVC_PRIORITY$svc_user -x $SVC_PATH -- \
 		-D --enable-rpc=true --conf-path="$FILE_CONF" --input-file="$FILE_LIST" --save-session="$FILE_LIST" \
-		--rpc-listen-port="$aria_rport" --listen-port="$aria_pport" --dht-listen-port="$aria_pport"
+		--rpc-listen-port="$aria_rport" --listen-port="$aria_pport" --dht-listen-port="$aria_pport" $SSL_OPT
 
 	if [ $? -eq 0 ] ; then
 		echo "[  OK  ]"

--- a/trunk/user/transmission/transmission.sh
+++ b/trunk/user/transmission/transmission.sh
@@ -28,7 +28,8 @@ func_start()
 	fi
 	
 	DIR_CFG="${DIR_LINK}/config"
-	DIR_DL1="${DIR_LINK}/downloads"
+	DIR_DL1="`cd \"$DIR_LINK\"; dirname \"$(pwd -P)\"`/Downloads"
+	[ ! -d "$DIR_DL1" ] && DIR_DL1="${DIR_LINK}/downloads"
 	DIR_DL2="${DIR_LINK}/incomplete"
 	DIR_DL3="${DIR_LINK}/watch"
 	

--- a/trunk/user/www/dict/CN.dict
+++ b/trunk/user/www/dict/CN.dict
@@ -419,6 +419,7 @@ StorageFTPD=FTP 服务器
 StorageNFSD=NFS 服务器
 StorageEnableNFSD=启用 NFS 服务器
 StorageAllowOptw=启用 Optware
+WebControl=控制台
 StorageFFly=iTunes 媒体服务器 (Firefly)
 StorageEnableFFly=启用 iTunes 媒体服务器:
 StorageTorrent=Torrent Transmission

--- a/trunk/user/www/dict/EN.footer
+++ b/trunk/user/www/dict/EN.footer
@@ -404,6 +404,7 @@ StorageFTPD=FTP Server
 StorageNFSD=NFS Server
 StorageEnableNFSD=Enable NFS Server?
 StorageAllowOptw=Allow Run Optware?
+WebControl=Web Control
 StorageFFly=iTunes Media Server (Firefly)
 StorageEnableFFly=Enable iTunes Media Server?
 StorageTorrent=Torrent Transmission

--- a/trunk/user/www/n56u_ribbon_fixed/Advanced_AiDisk_others.asp
+++ b/trunk/user/www/n56u_ribbon_fixed/Advanced_AiDisk_others.asp
@@ -127,8 +127,8 @@ var window_params="toolbar=yes,location=yes,directories=no,status=yes,menubar=ye
 
 function on_aria_link(){
 	var aria_url="http";
-	var http_url=lan_ipaddr;
-	if (http_proto=='1'){
+	var http_url=location.hostname;
+	if (http_proto!='0'){
 		aria_url+="s";
 		if (https_port!='443')
 			http_url+=":"+https_port;
@@ -141,19 +141,19 @@ function on_aria_link(){
 }
 
 function on_rpc_link(){
-	var rpc_url="http://" + lan_ipaddr + ":" + document.form.trmd_rport.value;
+	var rpc_url="http://" + location.hostname + ":" + document.form.trmd_rport.value;
 	window_rpc = window.open(rpc_url, "Transmission", window_params);
 	window_rpc.focus();
 }
 
 function on_dms_link(){
-	var dms_url="http://" + lan_ipaddr + ":8200";
+	var dms_url="http://" + location.hostname + ":8200";
 	window_dms = window.open(dms_url, "Minidlna", window_params);
 	window_dms.focus();
 }
 
 function on_ffly_link(){
-	var ffly_url="http://" + lan_ipaddr + ":3689";
+	var ffly_url="http://" + location.hostname + ":3689";
 	window_ffly = window.open(ffly_url, "Firefly", window_params);
 	window_ffly.focus();
 }
@@ -752,7 +752,7 @@ function done_validating(action){
                                                 </div>
                                             </td>
                                             <td width="15%">
-                                                <a href="javascript:on_ffly_link();" id="web_ffly_link">Web control</a>
+                                                <a href="javascript:on_ffly_link();" id="web_ffly_link"><#WebControl#></a>
                                             </td>
                                         </tr>
                                     </table>
@@ -794,7 +794,7 @@ function done_validating(action){
                                                <input type="text" maxlength="5" size="5" name="trmd_rport" class="input" value="<% nvram_get_x("", "trmd_rport"); %>" onkeypress="return is_number(this,event);"/>
                                             </td>
                                             <td>
-                                               <a href="javascript:on_rpc_link();" id="web_rpc_link">Web control</a>
+                                               <a href="javascript:on_rpc_link();" id="web_rpc_link"><#WebControl#></a>
                                             </td>
                                         </tr>
                                     </table>
@@ -836,7 +836,7 @@ function done_validating(action){
                                                <input type="text" maxlength="5" size="5" name="aria_rport" class="input" value="<% nvram_get_x("", "aria_rport"); %>" onkeypress="return is_number(this,event);"/>
                                             </td>
                                             <td>
-                                               <a href="javascript:on_aria_link();" id="web_aria_link">Web control</a>
+                                               <a href="javascript:on_aria_link();" id="web_aria_link"><#WebControl#></a>
                                             </td>
                                         </tr>
                                     </table>


### PR DESCRIPTION
1. 如果设置Padavan管理控制台为 HTTPS（或HTTPS+HTTP），则以将 aria2c 以 SSL 方式运行（证书复用来自HTTPS相关的配置文件），同时用 HTTPS 方式 打开 AriaNg；如果不做这个优化，HTTPS打开的AiraNg连接非SSL的aira rpc会默认无法连接，需要手动点击不安全信任。

2. 优化Aira、Transmission等控制台的打开URL，从 browser 的 window.location 中获取最佳的路径（而不是强制使用内网IP，会造成外网无法访问、以及HTTPS证书不对的问题）。

3. 检测外置硬盘如果有 Downloads 目录，优先使用该目录，而不是 aria/downloads和transmission/downloads。

4. aria 默认分配方式改为falloc，根据aria2c[官方文档](https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-file-allocation)，ext4、NTFS等现代文件系统下，falloc是最佳选择。