### PR TITLE
Fix mac lookup by using ieee service; Show href link on client hostname (if available)

### DIFF
--- a/trunk/user/www/n56u_ribbon_fixed/device-map/clients.asp
+++ b/trunk/user/www/n56u_ribbon_fixed/device-map/clients.asp
@@ -160,9 +160,9 @@ function add_client_row(table, atIndex, client, blocked, j){
 
 	typeCell.style.textAlign = "center";
 	typeCell.innerHTML = "<img title='"+ DEVICE_TYPE[client[5]]+"' src='/bootstrap/img/wl_device/" + client[5] +".gif'>";
-	nameCell.innerHTML = client[0];
+	nameCell.innerHTML = (client[6] == "1") ? "<a href=http://" + client[0] + " target='blank'>" + client[0] + "</a>" : client[0];
 	ipCell.innerHTML = (client[6] == "1") ? "<a href=http://" + client[1] + " target='blank'>" + client[1] + "</a>" : client[1];
-	macCell.innerHTML = "<a target='_blank' href='http://apps.neu.edu.cn/macquery/?mac=" + client[2].substr(0,2) + "%3A" + client[2].substr(2,2) + "%3A" + client[2].substr(4,2) + "'>" + mac_add_delimiters(client[2]) + "</a>";
+	macCell.innerHTML = "<a target='_blank' href='https://services13.ieee.org/RST/standards-ra-web/rest/assignments/?registry=MAC&text=" + client[2].substr(0,6) + "'>" + mac_add_delimiters(client[2]) + "</a>";
 	if (client[3] == 10){
 		rssiCell.innerHTML = client[4].toString();
 	}


### PR DESCRIPTION
1. 本PR主要功能是：修正 MAC 地址查询的服务页面——之前的东北大学的服务好像挂了，现在改为IEEE的应该会比较靠谱，虽然没有这么好看。如果你确信会恢复，请reject掉这个PR；
2. 顺便在client hostname 处也支持点击打开（如果ip能点击打开的情况下），hostname用作打开地址有助于浏览器记忆用户名和密码（当然IP也可以，但name更具友好性）。

