### PR TITLE
Veto files with ._* for macOS

### DIFF
--- a/trunk/user/rc/services_stor.c
+++ b/trunk/user/rc/services_stor.c
@@ -270,7 +270,8 @@ write_smb_conf(void)
 	fprintf(fp, "dos filetimes = yes\n");
 	fprintf(fp, "dos filetime resolution = yes\n");
 	fprintf(fp, "access based share enum = yes\n");
-	fprintf(fp, "veto files = /Thumbs.db/.DS_Store/._.DS_Store/.apdisk/.TemporaryItems/");
+	fprintf(fp, "veto files = /Thumbs.db/.DS_Store/._*/.apdisk/.TemporaryItems/");
+	fprintf(fp, "delete veto files = yes\n");
 	fprintf(fp, "\n");
 
 	disks_info = read_disk_data();


### PR DESCRIPTION
- 移除之前实际不会存在的“._.DS_Store”
- 删除macOS生成的牛皮鲜文件 ._*
