### PR TITLE
DDNS tips for 3322.org

### DIFF
--- a/trunk/user/www/dict/CN.dict
+++ b/trunk/user/www/dict/CN.dict
@@ -295,8 +295,8 @@ WAN_TTL_Value=路由器TTL值
 WAN_TTL_Value_Item0=默认值
 WAN_TTL_Value_Item1=64(Unix)
 WAN_TTL_Value_Item2=128(Windows)
-DDNS_SVR=动态 DNS 服务器 (FQDN 或 IP):
-DDNS_URL=动态 DNS 更新 URL:
+DNS_SVR=DDNS 服务器 (如 members.3322.net):
+DDNS_URL=DDNS URI (如 /dyndns/update?system=dyndns&hostname=):
 DDNS_Second=副动态域名服务 (DDNS) 设置
 DDNS_Common=动态域名服务 (DDNS) 通用设置
 DDNS_SSL=使用 HTTPS 安全连接?


### PR DESCRIPTION
Padavan的DDNS不支持3322.org是一个遗憾，不过可以通过自定义方式实现。但经常记不住配置的方法。此PR通过修改自定义DDNS的UI文案的方法，曲线支持3322.org DDNS的功能：）