### PR TITLE
Use falloc instead of trunc for airia2c

### DIFF
--- a/trunk/user/aria2/aria.sh
+++ b/trunk/user/aria2/aria.sh
@@ -66,8 +66,8 @@ max-overall-download-limit=0
 disable-ipv6=false
 
 ### File
-file-allocation=trunc
-#file-allocation=falloc
+#file-allocation=trunc
+file-allocation=falloc
 #file-allocation=none
 no-file-allocation-limit=10M
 allow-overwrite=false


### PR DESCRIPTION
aria2c 默认应该使用 falloc 分配空间，这是[https://aria2.github.io/manual/en/html/aria2c.html](aria2c官方文档)建议的，包括EXT4、NTFS、HPFS+这些文件系统都应该优先使用这种方式。

而且，官方文档中特别提到trunc方式的Warning(导致磁盘碎片)：
`Using trunc seemingly allocates disk space very quickly, but what it actually does is that it sets file length metadata in file system, and does not allocate disk space at all. This means that it does not help avoiding fragmentation.`