### PR TITLE
Show plain text for key file in safe login

### DIFF
--- a/trunk/user/httpd/web_ex.c
+++ b/trunk/user/httpd/web_ex.c
@@ -658,7 +658,7 @@ dump_file(webs_t wp, char *filename)
 	}
 
 	extensions = strrchr(filename, '.');
-	if (extensions && strcmp(extensions, ".key") == 0) {
+	if (!get_login_safe() && extensions && strcmp(extensions, ".key") == 0) {
 		return websWrite(wp, "%s", "# !!!This is hidden write-only secret key file!!!\n");
 	}
 


### PR DESCRIPTION
隐藏了 SSH KEY 和 SSL KEY，非常不方便查看和复制粘贴，实际上在 safe login 模式下，根本无需多此一举。