### PR TITLE
Add script for mounting SATA disk  (not enabled by default)

### DIFF
--- a/trunk/user/scripts/mtd_storage.sh
+++ b/trunk/user/scripts/mtd_storage.sh
@@ -265,6 +265,9 @@ func_fill()
 #drop caches
 sync && echo 3 > /proc/sys/vm/drop_caches
 
+# Mount SATA disk
+#mdev -s
+
 EOF
 		chmod 755 "$script_started"
 	fi


### PR DESCRIPTION
小娱C1支持SATA功能，但启动后仍需要手动执行mdev -s才能挂载SATA。此PR`在路由器启动后执行`的脚本里面增加了如下代码（实际修改mtd_storage.sh），默认注释掉了需用户手动启用：

```
# Mount SATA disk
#mdev -s

```
如果有无更好的方案，请reject掉这个方案。