### PR TITLE
Run aria in root in SSL mode (fix permission error at /etc/storage/ht…

### DIFF
--- a/trunk/user/aria2/aria.sh
+++ b/trunk/user/aria2/aria.sh
@@ -109,19 +109,19 @@ EOF
 	# aria2 needed home dir
 	export HOME="$DIR_CFG"
 
+	if [ "`nvram get http_proto`" != "0" ]; then
+		SVC_ROOT=1
+		SSL_OPT="--rpc-secure=true --rpc-certificate=/etc/storage/https/server.crt --rpc-private-key=/etc/storage/https/server.key"
+	else
+		SSL_OPT=
+	fi
+
 	svc_user=""
 
 	if [ $SVC_ROOT -eq 0 ] ; then
 		chmod 777 "${DIR_LINK}"
 		chown -R nobody "$DIR_CFG"
 		svc_user=" -c nobody"
-	fi
-
-	if [ "`nvram get http_proto`" != "0" ]; then
-		chmod 644 /etc/storage/https/server.crt /etc/storage/https/server.key
-		SSL_OPT="--rpc-secure=true --rpc-certificate=/etc/storage/https/server.crt --rpc-private-key=/etc/storage/https/server.key"
-	else
-		SSL_OPT=
 	fi
 
 	start-stop-daemon -S -N $SVC_PRIORITY$svc_user -x $SVC_PATH -- \


### PR DESCRIPTION
修复HTTPS模式下，aria2 脚本 RPC over SSL 运行时无法获取 /etc/storage/https权限的问题（默认权限为700）。

SSL模式下应足够安全，aria2运行于root下安全无虞。