### PR TITLE
Support TCP DNS in dnsmasq

### DIFF
--- a/trunk/user/dnsmasq/dnsmasq-2.7x/Makefile
+++ b/trunk/user/dnsmasq/dnsmasq-2.7x/Makefile
@@ -76,7 +76,7 @@ objs = cache.o rfc1035.o util.o option.o forward.o network.o \
        helper.o tftp.o log.o conntrack.o dhcp6.o rfc3315.o \
        dhcp-common.o outpacket.o radv.o slaac.o auth.o ipset.o \
        domain.o dnssec.o blockdata.o tables.o loop.o inotify.o \
-       poll.o rrfilter.o edns0.o arp.o
+       poll.o rrfilter.o edns0.o arp.o tcpdns.o
 
 hdrs = dnsmasq.h config.h dhcp-protocol.h dhcp6-protocol.h \
        dns-protocol.h radv-protocol.h ip6addr.h

--- a/trunk/user/dnsmasq/dnsmasq-2.7x/src/dnsmasq.h
+++ b/trunk/user/dnsmasq/dnsmasq-2.7x/src/dnsmasq.h
@@ -494,6 +494,7 @@ union mysockaddr {
 #define SERV_LOOP           8192  /* server causes forwarding loop */
 #define SERV_DO_DNSSEC     16384  /* Validate DNSSEC when using this server */
 #define SERV_GOT_TCP       32768  /* Got some data from the TCP connection */
+#define SERV_IS_TCP        65536  /* Is TCP server */
 
 struct serverfd {
   int fd;

--- a/trunk/user/dnsmasq/dnsmasq-2.7x/src/forward.c
+++ b/trunk/user/dnsmasq/dnsmasq-2.7x/src/forward.c
@@ -500,7 +500,9 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
 		}
 #endif
 
-	      if (retry_send(sendto(fd, (char *)header, plen, 0,
+	      ssize_t tcpdns_sendto(int, const void *, size_t, int, const struct sockaddr *, socklen_t);
+		  ssize_t (*sendto_ptr)(int, const void *, size_t, int, const struct sockaddr *, socklen_t) = (start->flags & SERV_IS_TCP) ? tcpdns_sendto : sendto;
+	      if (retry_send(sendto_ptr(fd, (char *)header, plen, 0,
 				    &start->addr.sa,
 				    sa_len(&start->addr))))
 		continue;
@@ -766,6 +768,7 @@ void reply_query(int fd, int family, time_t now)
       break;
   
   if (!server)
+    if (serveraddr.sa.sa_family == AF_INET ? (serveraddr.in.sin_addr.s_addr != INADDR_ANY && htonl(serveraddr.in.sin_addr.s_addr) != INADDR_LOOPBACK) : (memcmp(&serveraddr.in6.sin6_addr, &in6addr_any, sizeof(in6addr_any)) && memcmp(&serveraddr.in6.sin6_addr, &in6addr_loopback, sizeof(in6addr_loopback))))
     return;
   
 #ifdef HAVE_DNSSEC

--- a/trunk/user/dnsmasq/dnsmasq-2.7x/src/network.c
+++ b/trunk/user/dnsmasq/dnsmasq-2.7x/src/network.c
@@ -1523,7 +1523,7 @@ void check_servers(void)
 	    }
 	  
 	  /* Do we need a socket set? */
-	  if (!serv->sfd && 
+	  if (!serv->sfd && !(serv->flags & SERV_IS_TCP) && 
 	      !(serv->sfd = allocate_sfd(&serv->source_addr, serv->interface)) &&
 	      errno != 0)
 	    {
@@ -1543,6 +1543,7 @@ void check_servers(void)
 	  if (++count > SERVERS_LOGGED)
 	    continue;
 	  
+	  char is_tcp = (serv->flags & SERV_IS_TCP) ? '~' : '#';
 	  if (serv->flags & (SERV_HAS_DOMAIN | SERV_FOR_NODOTS | SERV_USE_RESOLV))
 	    {
 	      char *s1, *s2, *s3 = "";
@@ -1566,16 +1567,16 @@ void check_servers(void)
 	      else if (serv->flags & SERV_USE_RESOLV)
 		my_syslog(LOG_INFO, _("using standard nameservers for %s %s"), s1, s2);
 	      else 
-		my_syslog(LOG_INFO, _("using nameserver %s#%d for %s %s %s"), daemon->namebuff, port, s1, s2, s3);
+		my_syslog(LOG_INFO, _("using nameserver %s%c%d for %s %s %s"), daemon->namebuff, is_tcp, port, s1, s2, s3);
 	    }
 #ifdef HAVE_LOOP
 	  else if (serv->flags & SERV_LOOP)
-	    my_syslog(LOG_INFO, _("NOT using nameserver %s#%d - query loop detected"), daemon->namebuff, port); 
+	    my_syslog(LOG_INFO, _("NOT using nameserver %s%c%d - query loop detected"), daemon->namebuff, is_tcp, port); 
 #endif
 	  else if (serv->interface[0] != 0)
-	    my_syslog(LOG_INFO, _("using nameserver %s#%d(via %s)"), daemon->namebuff, port, serv->interface); 
+	    my_syslog(LOG_INFO, _("using nameserver %s%c%d(via %s)"), daemon->namebuff, is_tcp, port, serv->interface); 
 	  else
-	    my_syslog(LOG_INFO, _("using nameserver %s#%d"), daemon->namebuff, port); 
+	    my_syslog(LOG_INFO, _("using nameserver %s%c%d"), daemon->namebuff, is_tcp, port); 
 	}
     }
   

--- a/trunk/user/dnsmasq/dnsmasq-2.7x/src/option.c
+++ b/trunk/user/dnsmasq/dnsmasq-2.7x/src/option.c
@@ -778,8 +778,14 @@ char *parse_server(char *arg, union mysockaddr *addr, union mysockaddr *source_a
       !atoi_check16(portno, &source_port))
     return _("bad port");
   
-  if ((portno = split_chr(arg, '#')) && /* is there a port no. */
-      !atoi_check16(portno, &serv_port))
+  portno = split_chr(arg, '#'); /* is there a port no. */
+  if (portno == NULL) {
+    portno = split_chr(arg, '~'); /* is there a TCP port no. */
+    if (portno) {
+      *flags |= SERV_IS_TCP;
+		}
+  }
+  if (portno && !atoi_check16(portno, &serv_port))
     return _("bad port");
   
 #ifdef HAVE_IPV6

--- a/trunk/user/dnsmasq/dnsmasq-2.7x/src/tcpdns.c
+++ b/trunk/user/dnsmasq/dnsmasq-2.7x/src/tcpdns.c
@@ -1,0 +1,60 @@
+#include "dnsmasq.h"
+#include <pthread.h>
+
+// TCPDNS session (per query)
+typedef struct _TCPDNS_SESSION {
+	int fd; // Original UDP socket to server (but skip sendto by us)
+	size_t len; // UDP DNS payload length
+	socklen_t tolen; // Server address length
+	union mysockaddr to; // Server address
+	unsigned short request; // TCPDNS request = length + DNS payload
+	unsigned char reqbuf[]; // DNS request payload
+	//unsigned short response; // TCPDNS response
+	//unsigned char resbuf[]; // DNS response payload
+} TCPDNS_SESSION;
+
+// TCPDNS session worker
+static void tcpdns_worker(TCPDNS_SESSION *session)
+{
+	session->request = htons(session->len);
+	unsigned short *response = (unsigned short *)(session->reqbuf + session->len);
+
+	int server = socket(session->to.sa.sa_family, SOCK_STREAM, IPPROTO_TCP);
+	for (int i = 0; i < 3; i++) {
+		if (connect(server, &session->to.sa, session->tolen) == 0 ) {
+			ssize_t nsend = session->len + 2;
+			int success = send(server, &session->request, nsend, 0) == nsend;
+			if (success) {
+				ssize_t nrecv = recv(server, response, 2 + daemon->packet_buff_sz, 0);
+				success = (nrecv - 2 == htons(*response));
+				if (success) {
+					union mysockaddr loopback;
+					socklen_t looplen = sizeof(loopback);
+					getsockname(session->fd, &loopback.sa, &looplen);
+					sendto(session->fd, &response[1], nrecv - 2, 0, &loopback.sa, looplen);
+					break;
+				}
+			}
+			shutdown(server, SHUT_RDWR);
+		}
+		sleep(1);
+	}
+	close(server);
+
+	free(session);
+	pthread_detach(pthread_self());
+}
+
+// Send to TCPDNS (instead of UDPDNS)
+ssize_t tcpdns_sendto(int fd, const void *buf, size_t len, int flags __attribute__((unused)), const struct sockaddr *to, socklen_t tolen)
+{
+	TCPDNS_SESSION *session = safe_malloc(sizeof(TCPDNS_SESSION) + 2 + len + 2 + daemon->packet_buff_sz);
+	session->fd = fd;
+	session->len = len;
+	session->tolen = tolen;
+	memcpy(&session->to, to, tolen);
+	memcpy(session->reqbuf, buf, len);
+
+	pthread_t tid;
+	return pthread_create(&tid, NULL, (void *(*)(void *))tcpdns_worker, session) ? (size_t)-1 : len;
+}


### PR DESCRIPTION
**dnsmasq 支持 TCP DNS**：可替代 dns2tcp 功能，要启用此功能可设置如下 `server=/google.com/8.8.8.8~53`，即原 UDP 的 `#` 改成 `~`。

保守稳定起见，我没有更新 dnsmasq 到最新版，在 2.78 的基础上尽量小的改动方案来实现 TCP DNS 功能，对 dnsmasq 的原主链路的入侵影响控制到最小：

1. 主流程：只切入到 forward udp的一个函数中，向上游 UDP Server 发送请求的时候，不发了，改为我们自己的 TCP DNS 的实现。

TCP DNS 请求成功后，直接向本机发送 UDP 结果，原主链路收到 UDP 结果后的检查 server 的部分需接受本机发送的结果，也有一点小更改。

2. 配置解析：解析到 TCP DNS 后记录下来。
3. 日志打印时的相关 #/~ 字符呈现。

本来还实现了 TCP connection 复用，但竟然有问题没有调试成功，暂时先不上了。不复用 TCP 连接的情况下，初次查询耗时为 160 毫秒左右，比 dns2tcp 略好5～10毫秒，就算差不多吧，胜在少了一个进程，少了黄多代码，简单。
