### PR TITLE
Add host name record for dnsmasq dhcp-host

### DIFF
--- a/trunk/user/dnsmasq/dnsmasq-2.7x/src/option.c
+++ b/trunk/user/dnsmasq/dnsmasq-2.7x/src/option.c
@@ -3169,6 +3169,22 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 		     
 		      new->flags |= CONFIG_NAME;
 		      new->domain = strip_hostname(new->hostname);			
+		      if (new->flags & (CONFIG_ADDR | CONFIG_ADDR6)) {
+		        char *buf = daemon->namebuff;
+		        for (char *name = new->hostname; *name; name++) *buf++ = *name;
+		        if (new->flags & CONFIG_ADDR) {
+		          *buf++ = ',';
+		          inet_ntop(AF_INET, &new->addr, buf, MAXDNAME - 1 - (buf - daemon->namebuff));
+#ifdef HAVE_DHCP6
+		          buf += strlen(buf);
+		        }
+		        if (new->flags & CONFIG_ADDR6) {
+		          *buf++ = ',';
+		          inet_ntop(AF_INET6, &new->addr6, buf, MAXDNAME - 1 - (buf - daemon->namebuff));
+#endif
+		        }
+		        one_opt(LOPT_HOST_REC, daemon->namebuff, _("dhcp-host"), _("error"), 0, 0);
+		      }
 		    }
 		}
 	      else if (isdig)


### PR DESCRIPTION
**dnsmasq `dhcp-host` 主机名持久解析**

问题背景：Router + AP 情况下，Router 重启后 ，因设备连接 AP 而没有来重新 DHCP，导致 dnsmasq 无法解析 dhcp-host 中配置的 hostname。

解决方案：`dhcp-host`中如果包含 hostname，会自动添加一条 `host-record` 记录，以便解决上述问题。

改动：进在配置参数解析时添加一条记录，均为原功能调用，方案靠谱，**此 PR 需要更多测试，请先不要合并，可以合并了我会再来评论**。
