### PR TITLE
Support dhcp-to-host: Add host name record for dnsmasq dhcp-host

### DIFF
--- a/trunk/user/dnsmasq/dnsmasq-2.7x/src/dnsmasq.c
+++ b/trunk/user/dnsmasq/dnsmasq-2.7x/src/dnsmasq.c
@@ -1472,6 +1472,10 @@ void clear_cache_and_reload(time_t now)
       if (option_bool(OPT_ETHERS))
 	dhcp_read_ethers();
       reread_dhcp();
+      if (option_bool(OPT_DHCP_TO_HOST)) {
+        void dhcp_to_host();
+        dhcp_to_host();
+      }
 #ifdef HAVE_INOTIFY
       set_dynamic_inotify(AH_DHCP_HST | AH_DHCP_OPT, 0, NULL, 0);
 #endif

--- a/trunk/user/dnsmasq/dnsmasq-2.7x/src/dnsmasq.h
+++ b/trunk/user/dnsmasq/dnsmasq-2.7x/src/dnsmasq.h
@@ -245,7 +245,8 @@ struct event_desc {
 #define OPT_MAC_B64        54
 #define OPT_MAC_HEX        55
 #define OPT_TFTP_APREF_MAC 56
-#define OPT_LAST           57
+#define OPT_DHCP_TO_HOST   57
+#define OPT_LAST           58
 
 /* extra flags for my_syslog, we use a couple of facilities since they are known 
    not to occupy the same bits as priorities, no matter how syslog.h is set up. */

--- a/trunk/user/dnsmasq/dnsmasq-2.7x/src/option.c
+++ b/trunk/user/dnsmasq/dnsmasq-2.7x/src/option.c
@@ -161,6 +161,7 @@ struct myoption {
 #define LOPT_TFTP_MTU      349
 #define LOPT_REPLY_DELAY   350
 #define LOPT_GFWLIST       351
+#define LOPT_DHCP_TO_HOST  352
  
 #ifdef HAVE_GETOPT_LONG
 static const struct option opts[] =  
@@ -327,6 +328,7 @@ static const struct myoption opts[] =
     { "dhcp-ttl", 1, 0 , LOPT_DHCPTTL },
     { "dhcp-reply-delay", 1, 0, LOPT_REPLY_DELAY },
     { "gfwlist", 1, 0, LOPT_GFWLIST },
+	{ "dhcp-to-host", 0, 0, LOPT_DHCP_TO_HOST },
     { NULL, 0, 0, 0 }
   };
 
@@ -500,6 +502,7 @@ static struct {
   { LOPT_DHCPTTL, ARG_ONE, "<ttl>", gettext_noop("Set TTL in DNS responses with DHCP-derived addresses."), NULL }, 
   { LOPT_REPLY_DELAY, ARG_ONE, "<integer>", gettext_noop("Delay DHCP replies for at least number of seconds."), NULL },
   { LOPT_GFWLIST, ARG_DUP, "<path|domain>[@server][^ipset]", gettext_noop("Gfwlist path or domain to special server (default 8.8.8.8~53) and ipset (default gfwlist, pass ^ only to skip default ipset)"), NULL },
+  { LOPT_DHCP_TO_HOST, OPT_DHCP_TO_HOST, NULL, gettext_noop("Keep DHCP hostname valid at all times."), NULL },
   { 0, 0, NULL, NULL, NULL }
 }; 
 

--- a/trunk/user/scripts/mtd_storage.sh
+++ b/trunk/user/scripts/mtd_storage.sh
@@ -492,6 +492,9 @@ dhcp-option=252,"\n"
 ### Log for all queries
 #log-queries
 
+### Keep DHCP host name valid at any times
+#dhcp-to-host
+
 EOF
 	if [ -f /usr/bin/vlmcsd ]; then
 		cat >> "$user_dnsmasq_conf" <<EOF


### PR DESCRIPTION
**dnsmasq `dhcp-host` 主机名持久解析**

问题背景：Router + AP 情况下，Router 重启后 ，因设备连接 AP 而没有来重新 DHCP，导致 dnsmasq 无法解析 dhcp-host 中配置的 hostname。

解决方案：支持`dhcp-to-host`配置，当此配置开启后，遇到`dhcp-host`中包含 hostname时，会自动添加一条 `host-record` 记录，以便解决上述问题。

改动：参加考源码，在适当的时机调用原有代码实现相关功能；默认不启用，如果用户不增加配置，不会有实际影响；经几个月实际测试使用，结果符合预期。
