### PR TITLE
斐讯K2和K2P 灯光控制

### DIFF
--- a/trunk/user/rc/detect_internet.c
+++ b/trunk/user/rc/detect_internet.c
@@ -273,10 +273,15 @@ di_on_timer(void)
 		di_time_diff_state = now - di_time_last_state;
 		
 		nvram_set_int_temp("link_internet", link_internet);
-		
-#if defined (BOARD_GPIO_LED_WAN)
-		if (nvram_get_int("front_led_wan") == 3)
+#if ((BOARD_GPIO_LED_POWER == 13 && BOARD_GPIO_LED_WIFI == 14 && BOARD_GPIO_LED_WAN ==15) || (BOARD_GPIO_LED_POWER == 8 && BOARD_GPIO_LED_WIFI == 11 && BOARD_GPIO_LED_WAN ==10))
+		if (nvram_get_int("front_led_wan") == 3){
 			LED_CONTROL(BOARD_GPIO_LED_WAN, (link_internet) ? LED_ON : LED_OFF);
+			LED_CONTROL(BOARD_GPIO_LED_WIFI, (link_internet) ? LED_OFF : LED_ON);
+		}
+#elif defined (BOARD_GPIO_LED_WAN)
+		if (nvram_get_int("front_led_wan") == 3){
+			LED_CONTROL(BOARD_GPIO_LED_WAN, (link_internet) ? LED_ON : LED_OFF);
+		}
 #endif
 		if (di_poll_mode != 0 && !di_pause_received) {
 			long fail_delay = (long)nvram_safe_get_int("di_lost_delay", 10, 0, 600);

--- a/trunk/user/rc/detect_link.c
+++ b/trunk/user/rc/detect_link.c
@@ -91,17 +91,32 @@ dl_handle_link_wan(void)
 		dl_status_wan_old = dl_status_wan;
 		
 		nvram_set_int_temp("link_wan", (dl_status_wan) ? 1 : 0);
-#if defined (BOARD_GPIO_LED_WAN)
+#if ((BOARD_GPIO_LED_POWER == 13 && BOARD_GPIO_LED_WIFI == 14 && BOARD_GPIO_LED_WAN ==15) || (BOARD_GPIO_LED_POWER == 8 && BOARD_GPIO_LED_WIFI == 11 && BOARD_GPIO_LED_WAN ==10))
 		front_led_x = nvram_get_int("front_led_wan");
-		if (front_led_x == 1)
+		if (front_led_x == 1) {
 			LED_CONTROL(BOARD_GPIO_LED_WAN, (dl_status_wan) ? LED_ON : LED_OFF);
-		else if (front_led_x == 2) {
+			LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_status_wan) ? LED_OFF : LED_ON);
+		} else if (front_led_x == 2) {
+			if (!get_wan_wisp_active(NULL) && !get_usb_modem_wan(0)) {
+				int dl_state = (dl_status_wan && has_wan_gw4() && has_wan_ip4(1)) ? 1 : 0;
+				LED_CONTROL(BOARD_GPIO_LED_WAN, (dl_state) ? LED_ON : LED_OFF);
+				LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_state) ? LED_OFF : LED_ON);
+			}
+		}
+#elif defined (BOARD_GPIO_LED_WAN)
+		front_led_x = nvram_get_int("front_led_wan");
+		if (front_led_x == 1) {
+			LED_CONTROL(BOARD_GPIO_LED_WAN, (dl_status_wan) ? LED_ON : LED_OFF);
+		} else if (front_led_x == 2) {
 			if (!get_wan_wisp_active(NULL) && !get_usb_modem_wan(0)) {
 				int dl_state = (dl_status_wan && has_wan_gw4() && has_wan_ip4(1)) ? 1 : 0;
 				LED_CONTROL(BOARD_GPIO_LED_WAN, (dl_state) ? LED_ON : LED_OFF);
 			}
 		}
 #endif
+
+
+
 #if defined (BOARD_GPIO_LED_LAN)
 		front_led_x = nvram_get_int("front_led_lan");
 		if (front_led_x == 1)


### PR DESCRIPTION
灯光与原版相同。网络连接时仅亮起蓝灯，不亮黄灯。无网络时亮起黄灯