### PR TITLE
miniupnpd: default disable IPv6 and IGDv2 options

### DIFF
--- a/trunk/user/miniupnpd/Makefile
+++ b/trunk/user/miniupnpd/Makefile
@@ -5,12 +5,12 @@ IPT_VERSION:=iptables-1.4.16.3
 
 # disable support IPv6 yet, because no profit w/o IGDv2
 # e.g. Windows not supported IGDv2 and UPnP not worked
-ENABLE_IPV6:=1
+ENABLE_IPV6:=0
 
 IPTABLESPATH=$(ROOTDIR)/user/iptables/$(IPT_VERSION)
 
 all:
-	cd $(SRC_NAME) && ./genconfig.sh --ipv6 --igd2
+	cd $(SRC_NAME) && ./genconfig.sh
 	$(MAKE) -f Makefile.linux -C $(SRC_NAME) IPTABLESPATH=$(IPTABLESPATH) ENABLE_IPV6=$(ENABLE_IPV6)
 
 clean:


### PR DESCRIPTION
default disable miniupnpd IPv6 and IGDv2 options for devices not supported IGDv2.
eg: all windows devices.