### PR TITLE
Shadowsocks: simple lan acl

### DIFF
--- a/trunk/user/shadowsocks/scripts/ss-rules
+++ b/trunk/user/shadowsocks/scripts/ss-rules
@@ -64,9 +64,9 @@ flush_rules() {
 
 ipset_init() {
 	ipset -! restore <<-EOF || return 1
-		create ss_spec_src_ac hash:mac hashsize 64
-		create ss_spec_src_bp hash:mac hashsize 64
-		create ss_spec_src_fw hash:mac hashsize 64
+		create ss_spec_src_ac hash:net hashsize 64
+		create ss_spec_src_bp hash:net hashsize 64
+		create ss_spec_src_fw hash:net hashsize 64
 		create ss_spec_dst_sp hash:net hashsize 64
 		create ss_spec_dst_bp hash:net hashsize 64
 		create ss_spec_dst_fw hash:net hashsize 64
@@ -172,9 +172,9 @@ include_ac_rules() {
 	:SS_SPEC_WAN_FW - [0:0]
 	-A SS_SPEC_LAN_DG -m set --match-set ss_spec_dst_sp dst -j RETURN
 	-A SS_SPEC_LAN_DG -p $protocol $EXT_ARGS -j SS_SPEC_LAN_AC
-	-A SS_SPEC_LAN_AC -m set --match-set ss_spec_src_bp src -j RETURN
 	-A SS_SPEC_LAN_AC -m set --match-set ss_spec_src_fw src -j SS_SPEC_WAN_FW
 	-A SS_SPEC_LAN_AC -m set --match-set ss_spec_src_ac src -j SS_SPEC_WAN_AC
+	-A SS_SPEC_LAN_AC -m set --match-set ss_spec_src_bp src -j RETURN
 	-A SS_SPEC_LAN_AC -j ${LAN_TARGET:=SS_SPEC_WAN_AC}
 	-A SS_SPEC_WAN_AC -m set --match-set ss_spec_dst_fw dst -j SS_SPEC_WAN_FW
 	-A SS_SPEC_WAN_AC -m set --match-set ss_spec_dst_bp dst -j RETURN


### PR DESCRIPTION
- 修改ipset ss_spec_src*类型从hash:mac变成hash:net，ip地址做acl更方便
- 降低ss_spec_src_bp的优先级，这样可以bypass整个lan地址段而只对指定lan ip代理