### PR TITLE
Fix TCP DNS crash in dnsmasq 2.8

### DIFF
--- a/trunk/user/dnsmasq/dnsmasq-2.8x/src/forward.c
+++ b/trunk/user/dnsmasq/dnsmasq-2.8x/src/forward.c
@@ -832,11 +832,12 @@ void reply_query(int fd, int family, time_t now)
       break;
   
   if (!server)
+  {
     if (serveraddr.sa.sa_family == AF_INET ? (serveraddr.in.sin_addr.s_addr != INADDR_ANY && htonl(serveraddr.in.sin_addr.s_addr) != INADDR_LOOPBACK) : (memcmp(&serveraddr.in6.sin6_addr, &in6addr_any, sizeof(in6addr_any)) && memcmp(&serveraddr.in6.sin6_addr, &in6addr_loopback, sizeof(in6addr_loopback))))
-    return;
-
+      return;
+  }
   /* If sufficient time has elapsed, try and expand UDP buffer size again. */
-  if (difftime(now, server->pktsz_reduced) > UDP_TEST_TIME)
+  else if (difftime(now, server->pktsz_reduced) > UDP_TEST_TIME)
     server->edns_pktsz = daemon->edns_pktsz;
 
   hash = hash_questions(header, n, daemon->namebuff);


### PR DESCRIPTION
之前升级 dnsmasq 2.8 的过程中，遗漏了2.8中对 TCPDNS server 的判空，导致crash。问题来源 https://github.com/hanwckf/rt-n56u/issues/684

现已修复，终于可以正常使用 `--gfwlist=` 参数了， `wing` 功能也正常了