### PR TITLE
Add nginx to avoid slow web from iOS/MacOS

### DIFF
--- a/trunk/user/Makefile
+++ b/trunk/user/Makefile
@@ -218,6 +218,10 @@ endif
 dir_y						+= mtd-utils
 endif
 
+ifeq ($(CONFIG_FIRMWARE_INCLUDE_NGINX),y)
+	dir_y						+= nginx
+endif
+
 all:
 	for i in $(dir_y) ; do \
 		[ ! -d $$i ] || \

--- a/trunk/user/nginx/Makefile
+++ b/trunk/user/nginx/Makefile
@@ -1,0 +1,49 @@
+THISDIR=$(shell pwd)
+
+PPPD_DIR=$(ROOTDIR)/user/nginx
+
+CFLAGS  += -O2
+CFLAGS  += -ffunction-sections -fdata-sections
+LDFLAGS += -Wl,--gc-sections
+
+SRC_VER = 1.20.2
+SRC_NAME = nginx-$(SRC_VER)
+SRC_FILE = $(SRC_NAME).tar.gz
+SRC_URL := http://nginx.org/download/$(SRC_FILE)
+
+all: download_test extra_test config_test
+	$(MAKE) -C $(SRC_NAME)
+
+download_test:
+	( if [ ! -f $(SRC_NAME).tar.gz ]; then \
+		wget -t5 --timeout=20 --no-check-certificate -O $(SRC_FILE) $(SRC_URL); \
+	fi )
+
+extra_test:
+	( if [ ! -d $(SRC_NAME) ]; then \
+		tar xf $(SRC_FILE); \
+		sed -i 's/if \/bin\/sh/if \(echo march \| grep march\) \|\| \/bin\/sh/' $(SRC_NAME)/auto/feature ; \
+		sed -i 's/if \[ -x/if \(echo march \| grep march\)\; then ngx_size=4; elif \[ -x/' $(SRC_NAME)/auto/types/sizeof ; \
+	fi )
+
+config_test:
+	( if [ -f ./config_done ]; then \
+		echo "the same configuration"; \
+	else \
+		make configure && touch config_done; \
+	fi )
+
+configure:
+	( cd $(SRC_NAME) ; \
+	./configure --without-http_rewrite_module --without-http_gzip_module --prefix=/tmp/var --conf-path=/tmp/var/nginx.conf --pid-path=/tmp/var/nginx.pid --error-log-path=/tmp/var/nginx.log --http-log-path=/tmp/var/access.log; \
+	)
+
+clean:
+	if [ -f $(SRC_NAME)/Makefile ] ; then \
+		$(MAKE) -C $(SRC_NAME) distclean ; \
+	fi ; \
+	rm -f config_done
+
+romfs:
+	$(ROMFSINST) -p +x $(THISDIR)/$(SRC_NAME)/objs/nginx /usr/bin/nginx
+	$(ROMFSINST) -p +x $(THISDIR)/nginx.sh /usr/bin/nginx.sh

--- a/trunk/user/nginx/nginx.sh
+++ b/trunk/user/nginx/nginx.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+cat << EOF > /tmp/var/nginx.conf
+events { }
+http {
+ server {
+  listen 88;
+  location / {
+   proxy_pass http://$(nvram get lan_ipaddr):80;
+   proxy_set_header Host host;
+   proxy_set_header X-Real-IP emote_addr;
+   proxy_set_header X-Forwarded_For proxy_add_x_forwarded_for;
+  }
+ }
+} 
+EOF
+nginx


### PR DESCRIPTION
添加了 nginx 反向代理进程，用途：1. 启动后运行 nginx.sh 可在 88 端口反向代理到 路由器 80 端口，以此解决 iOS/MacOS 访问 Padavan 巨缓慢的问题（不是根本解决，绕过解决）；2. 其它nginx用途。

问题来源：https://github.com/hanwckf/rt-n56u/issues/700
https://www.right.com.cn/forum/thread-550039-1-1.html
https://www.v2ex.com/t/790986
https://www.right.com.cn/forum/forum.php?mod=viewthread&tid=4768388&page=2#pid16402233


需要手动添加配置：

`CONFIG_FIRMWARE_INCLUDE_NGINX=y`
