### PR TITLE
MI-NANO LED Control Update

### DIFF
--- a/trunk/configs/boards/MI-NANO/board.h
+++ b/trunk/configs/boards/MI-NANO/board.h
@@ -14,7 +14,7 @@
 #define BOARD_GPIO_LED_WIFI	11
 #define BOARD_GPIO_LED_POWER	44	/* 11: blue, 37: red, 44: yellow */
 #undef  BOARD_GPIO_LED_LAN
-#undef  BOARD_GPIO_LED_WAN
+#define BOARD_GPIO_LED_WAN  37
 #define BOARD_HAS_5G_11AC	0
 #define BOARD_NUM_ANT_5G_TX	0
 #define BOARD_NUM_ANT_5G_RX	0

--- a/trunk/configs/boards/MI-NANO/board.h
+++ b/trunk/configs/boards/MI-NANO/board.h
@@ -11,10 +11,10 @@
 #define BOARD_GPIO_BTN_RESET	38
 #undef  BOARD_GPIO_BTN_WPS
 #undef  BOARD_GPIO_LED_ALL
-#define BOARD_GPIO_LED_WIFI	11
-#define BOARD_GPIO_LED_POWER	44	/* 11: blue, 37: red, 44: yellow */
+#define BOARD_GPIO_LED_WIFI	44
+#define BOARD_GPIO_LED_POWER	37	/* 11: blue, 37: red, 44: yellow */
 #undef  BOARD_GPIO_LED_LAN
-#define BOARD_GPIO_LED_WAN  37
+#define BOARD_GPIO_LED_WAN  11
 #define BOARD_HAS_5G_11AC	0
 #define BOARD_NUM_ANT_5G_TX	0
 #define BOARD_NUM_ANT_5G_RX	0

--- a/trunk/user/rc/detect_internet.c
+++ b/trunk/user/rc/detect_internet.c
@@ -279,6 +279,7 @@ di_on_timer(void)
 			LED_CONTROL(BOARD_GPIO_LED_WAN, (link_internet) ? LED_ON : LED_OFF);
 #if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 			LED_CONTROL(BOARD_GPIO_LED_WIFI, (link_internet) ? LED_OFF : LED_ON);
+            LED_CONTROL(BOARD_GPIO_LED_POWER, (link_internet) ? LED_OFF : LED_ON);
 #endif
 		}
 #endif

--- a/trunk/user/rc/detect_internet.c
+++ b/trunk/user/rc/detect_internet.c
@@ -277,7 +277,7 @@ di_on_timer(void)
 #if defined (BOARD_GPIO_LED_WAN)
 		if (nvram_get_int("front_led_wan") == 3){
 			LED_CONTROL(BOARD_GPIO_LED_WAN, (link_internet) ? LED_ON : LED_OFF);
-#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MI-NANO)
+#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 			LED_CONTROL(BOARD_GPIO_LED_WIFI, (link_internet) ? LED_OFF : LED_ON);
 #endif
 		}

--- a/trunk/user/rc/detect_internet.c
+++ b/trunk/user/rc/detect_internet.c
@@ -279,7 +279,7 @@ di_on_timer(void)
 			LED_CONTROL(BOARD_GPIO_LED_WAN, (link_internet) ? LED_ON : LED_OFF);
 #if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 			LED_CONTROL(BOARD_GPIO_LED_WIFI, (link_internet) ? LED_OFF : LED_ON);
-            LED_CONTROL(BOARD_GPIO_LED_POWER, (link_internet) ? LED_OFF : LED_ON);
+            LED_CONTROL(BOARD_GPIO_LED_POWER, LED_OFF);
 #endif
 		}
 #endif

--- a/trunk/user/rc/detect_internet.c
+++ b/trunk/user/rc/detect_internet.c
@@ -277,7 +277,7 @@ di_on_timer(void)
 #if defined (BOARD_GPIO_LED_WAN)
 		if (nvram_get_int("front_led_wan") == 3){
 			LED_CONTROL(BOARD_GPIO_LED_WAN, (link_internet) ? LED_ON : LED_OFF);
-#if defined (BOARD_K2P) || defined (BOARD_PSG1218)
+#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MI-NANO)
 			LED_CONTROL(BOARD_GPIO_LED_WIFI, (link_internet) ? LED_OFF : LED_ON);
 #endif
 		}

--- a/trunk/user/rc/detect_link.c
+++ b/trunk/user/rc/detect_link.c
@@ -97,6 +97,7 @@ dl_handle_link_wan(void)
 			LED_CONTROL(BOARD_GPIO_LED_WAN, (dl_status_wan) ? LED_ON : LED_OFF);
 #if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 			LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_status_wan) ? LED_OFF : LED_ON);
+            LED_CONTROL(BOARD_GPIO_LED_POWER, (dl_status_wan) ? LED_OFF : LED_ON);
 #endif
 		} else if (front_led_x == 2) {
 			if (!get_wan_wisp_active(NULL) && !get_usb_modem_wan(0)) {
@@ -104,6 +105,7 @@ dl_handle_link_wan(void)
 				LED_CONTROL(BOARD_GPIO_LED_WAN, (dl_state) ? LED_ON : LED_OFF);
 #if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 				LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_state) ? LED_OFF : LED_ON);
+				LED_CONTROL(BOARD_GPIO_LED_POWER, (dl_state) ? LED_OFF : LED_ON);
 #endif
 			}
 		}
@@ -192,6 +194,7 @@ dl_handle_link_wisp(void)
 			LED_CONTROL(BOARD_GPIO_LED_WAN, (dl_state) ? LED_ON : LED_OFF);
 #if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 			LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_state) ? LED_OFF : LED_ON);
+			LED_CONTROL(BOARD_GPIO_LED_POWER, (dl_state) ? LED_OFF : LED_ON);
 #endif
 		}
 #endif

--- a/trunk/user/rc/detect_link.c
+++ b/trunk/user/rc/detect_link.c
@@ -349,6 +349,7 @@ dl_update_leds(void)
 #endif
 #if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 	LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_state) ? LED_OFF : LED_ON);
+	LED_CONTROL(BOARD_GPIO_LED_POWER, LED_OFF);
 #elif defined (BOARD_GPIO_LED_WIFI)
 	LED_CONTROL(BOARD_GPIO_LED_WIFI, LED_ON);
 #endif

--- a/trunk/user/rc/detect_link.c
+++ b/trunk/user/rc/detect_link.c
@@ -97,7 +97,7 @@ dl_handle_link_wan(void)
 			LED_CONTROL(BOARD_GPIO_LED_WAN, (dl_status_wan) ? LED_ON : LED_OFF);
 #if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 			LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_status_wan) ? LED_OFF : LED_ON);
-            LED_CONTROL(BOARD_GPIO_LED_POWER, (dl_status_wan) ? LED_OFF : LED_ON);
+            LED_CONTROL(BOARD_GPIO_LED_POWER, LED_OFF);
 #endif
 		} else if (front_led_x == 2) {
 			if (!get_wan_wisp_active(NULL) && !get_usb_modem_wan(0)) {
@@ -105,7 +105,7 @@ dl_handle_link_wan(void)
 				LED_CONTROL(BOARD_GPIO_LED_WAN, (dl_state) ? LED_ON : LED_OFF);
 #if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 				LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_state) ? LED_OFF : LED_ON);
-				LED_CONTROL(BOARD_GPIO_LED_POWER, (dl_state) ? LED_OFF : LED_ON);
+				LED_CONTROL(BOARD_GPIO_LED_POWER, LED_OFF);
 #endif
 			}
 		}
@@ -194,7 +194,7 @@ dl_handle_link_wisp(void)
 			LED_CONTROL(BOARD_GPIO_LED_WAN, (dl_state) ? LED_ON : LED_OFF);
 #if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 			LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_state) ? LED_OFF : LED_ON);
-			LED_CONTROL(BOARD_GPIO_LED_POWER, (dl_state) ? LED_OFF : LED_ON);
+			LED_CONTROL(BOARD_GPIO_LED_POWER, LED_OFF);
 #endif
 		}
 #endif

--- a/trunk/user/rc/detect_link.c
+++ b/trunk/user/rc/detect_link.c
@@ -95,14 +95,14 @@ dl_handle_link_wan(void)
 		front_led_x = nvram_get_int("front_led_wan");
 		if (front_led_x == 1) {
 			LED_CONTROL(BOARD_GPIO_LED_WAN, (dl_status_wan) ? LED_ON : LED_OFF);
-#if defined (BOARD_K2P) || defined (BOARD_PSG1218)
+#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MI-NANO)
 			LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_status_wan) ? LED_OFF : LED_ON);
 #endif
 		} else if (front_led_x == 2) {
 			if (!get_wan_wisp_active(NULL) && !get_usb_modem_wan(0)) {
 				int dl_state = (dl_status_wan && has_wan_gw4() && has_wan_ip4(1)) ? 1 : 0;
 				LED_CONTROL(BOARD_GPIO_LED_WAN, (dl_state) ? LED_ON : LED_OFF);
-#if defined (BOARD_K2P) || defined (BOARD_PSG1218)
+#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MI-NANO)
 				LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_state) ? LED_OFF : LED_ON);
 #endif
 			}
@@ -190,7 +190,7 @@ dl_handle_link_wisp(void)
 		if (front_led_wan == 2) {
 			int dl_state = (dl_status_wisp && has_wan_gw4() && has_wan_ip4(1)) ? 1 : 0;
 			LED_CONTROL(BOARD_GPIO_LED_WAN, (dl_state) ? LED_ON : LED_OFF);
-#if defined (BOARD_K2P) || defined (BOARD_PSG1218)
+#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MI-NANO)
 			LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_state) ? LED_OFF : LED_ON);
 #endif
 		}
@@ -344,7 +344,7 @@ dl_update_leds(void)
 		dl_handle_link_usb(1);
 	}
 #endif
-#if defined (BOARD_K2P) || defined (BOARD_PSG1218)
+#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MI-NANO)
 	LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_state) ? LED_OFF : LED_ON);
 #elif defined (BOARD_GPIO_LED_WIFI)
 	LED_CONTROL(BOARD_GPIO_LED_WIFI, LED_ON);

--- a/trunk/user/rc/detect_link.c
+++ b/trunk/user/rc/detect_link.c
@@ -95,14 +95,14 @@ dl_handle_link_wan(void)
 		front_led_x = nvram_get_int("front_led_wan");
 		if (front_led_x == 1) {
 			LED_CONTROL(BOARD_GPIO_LED_WAN, (dl_status_wan) ? LED_ON : LED_OFF);
-#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MI-NANO)
+#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 			LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_status_wan) ? LED_OFF : LED_ON);
 #endif
 		} else if (front_led_x == 2) {
 			if (!get_wan_wisp_active(NULL) && !get_usb_modem_wan(0)) {
 				int dl_state = (dl_status_wan && has_wan_gw4() && has_wan_ip4(1)) ? 1 : 0;
 				LED_CONTROL(BOARD_GPIO_LED_WAN, (dl_state) ? LED_ON : LED_OFF);
-#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MI-NANO)
+#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 				LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_state) ? LED_OFF : LED_ON);
 #endif
 			}
@@ -190,7 +190,7 @@ dl_handle_link_wisp(void)
 		if (front_led_wan == 2) {
 			int dl_state = (dl_status_wisp && has_wan_gw4() && has_wan_ip4(1)) ? 1 : 0;
 			LED_CONTROL(BOARD_GPIO_LED_WAN, (dl_state) ? LED_ON : LED_OFF);
-#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MI-NANO)
+#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 			LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_state) ? LED_OFF : LED_ON);
 #endif
 		}
@@ -344,7 +344,7 @@ dl_update_leds(void)
 		dl_handle_link_usb(1);
 	}
 #endif
-#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MI-NANO)
+#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 	LED_CONTROL(BOARD_GPIO_LED_WIFI, (dl_state) ? LED_OFF : LED_ON);
 #elif defined (BOARD_GPIO_LED_WIFI)
 	LED_CONTROL(BOARD_GPIO_LED_WIFI, LED_ON);

--- a/trunk/user/rc/net_wan.c
+++ b/trunk/user/rc/net_wan.c
@@ -94,13 +94,13 @@ control_wan_led_isp_state(int is_wan_up, int is_modem_unit)
 				has_link = get_wan_ether_link_cached();
 		}
 		LED_CONTROL(BOARD_GPIO_LED_WAN, (is_wan_up && has_link) ? LED_ON : LED_OFF);
-#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MI-NANO)
+#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 		LED_CONTROL(BOARD_GPIO_LED_WIFI, (is_wan_up && has_link) ? LED_OFF : LED_ON);
 #endif
 	} else if (front_led_wan == 3) {
 		if (!is_wan_up)
 			LED_CONTROL(BOARD_GPIO_LED_WAN, LED_OFF);
-#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MI-NANO)
+#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 		LED_CONTROL(BOARD_GPIO_LED_WIFI, LED_ON);
 #endif
 	}

--- a/trunk/user/rc/net_wan.c
+++ b/trunk/user/rc/net_wan.c
@@ -94,13 +94,13 @@ control_wan_led_isp_state(int is_wan_up, int is_modem_unit)
 				has_link = get_wan_ether_link_cached();
 		}
 		LED_CONTROL(BOARD_GPIO_LED_WAN, (is_wan_up && has_link) ? LED_ON : LED_OFF);
-#if defined (BOARD_K2P) || defined (BOARD_PSG1218)
+#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MI-NANO)
 		LED_CONTROL(BOARD_GPIO_LED_WIFI, (is_wan_up && has_link) ? LED_OFF : LED_ON);
 #endif
 	} else if (front_led_wan == 3) {
 		if (!is_wan_up)
 			LED_CONTROL(BOARD_GPIO_LED_WAN, LED_OFF);
-#if defined (BOARD_K2P) || defined (BOARD_PSG1218)
+#if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MI-NANO)
 		LED_CONTROL(BOARD_GPIO_LED_WIFI, LED_ON);
 #endif
 	}

--- a/trunk/user/rc/net_wan.c
+++ b/trunk/user/rc/net_wan.c
@@ -103,6 +103,7 @@ control_wan_led_isp_state(int is_wan_up, int is_modem_unit)
 			LED_CONTROL(BOARD_GPIO_LED_WAN, LED_OFF);
 #if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 		LED_CONTROL(BOARD_GPIO_LED_WIFI, LED_ON);
+        LED_CONTROL(BOARD_GPIO_LED_POWER, LED_OFF);
 #endif
 	}
 #endif

--- a/trunk/user/rc/net_wan.c
+++ b/trunk/user/rc/net_wan.c
@@ -96,7 +96,7 @@ control_wan_led_isp_state(int is_wan_up, int is_modem_unit)
 		LED_CONTROL(BOARD_GPIO_LED_WAN, (is_wan_up && has_link) ? LED_ON : LED_OFF);
 #if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 		LED_CONTROL(BOARD_GPIO_LED_WIFI, (is_wan_up && has_link) ? LED_OFF : LED_ON);
-		LED_CONTROL(BOARD_GPIO_LED_POWER, (is_wan_up && has_link) ? LED_OFF : LED_ON);
+		LED_CONTROL(BOARD_GPIO_LED_POWER, LED_OFF);
 #endif
 	} else if (front_led_wan == 3) {
 		if (!is_wan_up)

--- a/trunk/user/rc/net_wan.c
+++ b/trunk/user/rc/net_wan.c
@@ -96,6 +96,7 @@ control_wan_led_isp_state(int is_wan_up, int is_modem_unit)
 		LED_CONTROL(BOARD_GPIO_LED_WAN, (is_wan_up && has_link) ? LED_ON : LED_OFF);
 #if defined (BOARD_K2P) || defined (BOARD_PSG1218) || defined (BOARD_MINANO)
 		LED_CONTROL(BOARD_GPIO_LED_WIFI, (is_wan_up && has_link) ? LED_OFF : LED_ON);
+		LED_CONTROL(BOARD_GPIO_LED_POWER, (is_wan_up && has_link) ? LED_OFF : LED_ON);
 #endif
 	} else if (front_led_wan == 3) {
 		if (!is_wan_up)


### PR DESCRIPTION
改动：
- MI-NANO重新定义灯
蓝色：WAN灯
黄色：WIFI灯
红色：POWER灯

- 优化K2，K2P，NANO的亮灯逻辑
 即：当蓝灯亮或者黄灯亮时，红灯会关闭

达成效果：
- 连接上ISP：只有蓝灯
- 无法连接ISP：只有黄灯